### PR TITLE
Rename `main.rs` to `lib.rs` on `compile`, if appropriate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ want to do `cargo run`. (It'll suggest `cargo test` intead if you've added a
 test, just like <https://play.rust-lang.org>. And if your file has neither `fn
 main` nor a test, it'll offer `cargo check`.)
 
+If you delete the `fn main` from your playground, `M-x compile` will quietly
+rename your Rust file from `main.rs` to `lib.rs` (to keep `rustc` from
+complaining that you don't have a `fn main`).
+
 
 ### Installation
 
@@ -16,9 +20,6 @@ Grab the source, open `play-rust.el`, and do `M-x package-install-from-buffer`.
 ### Future directions
 
 *   Basics:
-
-    *   Make compilation work even if you've deleted `main`, perhaps by
-        silently renaming the file and buffer to `lib.rs`.
 
     *   Eliminate the "`main.rs` is not part of any project. Select action:"
         speed bump.
@@ -33,6 +34,9 @@ Grab the source, open `play-rust.el`, and do `M-x package-install-from-buffer`.
         `compile-command` does not match our last suggestion exactly.)
 
     *   Suggest `+nightly` if the buffer contains `#![feature`.
+
+    *   Prevent `lsp-mode` from getting very angry-faced when the user deletes
+        `fn main`, until the next `compile`.
 
 *   Auto-populate Cargo.toml dependencies on compilation (e.g. if I use
     `rand::random`, don't force me to edit `Cargo.toml`)

--- a/play-rust.el
+++ b/play-rust.el
@@ -83,16 +83,39 @@
 
 (defun play-rust--compile-suggest ()
   "Find a reasonable `cargo` command to try to run, based on the
-content of the current buffer."
-  (save-excursion
-    (goto-char (point-min))
-    (cond
-     ((re-search-forward "#\\s-*\\[\\s-*test\\s-*\\]" nil t)
-      (concat play-rust-cargo-command " test "))
-     ((re-search-forward "\\_<fn\\s-+main\\_>" nil t)
-      (concat play-rust-cargo-command " run "))
-     (t
-      (concat play-rust-cargo-command " check ")))))
+content of the current buffer. Also rename the file if needed
+(see `play-rust--maybe-rename-file')."
+  (let*
+      ((has-test
+        (save-excursion
+          (goto-char (point-min))
+          (re-search-forward "#\\s-*\\[\\s-*test\\s-*\\]" nil t)))
+       (has-main
+        (save-excursion
+          (goto-char (point-min))
+          (re-search-forward "\\_<fn\\s-+main\\_>" nil t))))
+    (play-rust--maybe-rename-file has-main)
+    (concat play-rust-cargo-command
+            " "
+            (cond (has-test "test") (has-main "run") (t "check"))
+            " ")))
+
+(defun play-rust--maybe-rename-file (has-main)
+  "If `has-main' is nil, quietly try to rename the file and
+buffer to `lib.rs`, so `cargo` will build it as a library. If
+`has-main' is non-nil, rename back to `main.rs`.
+
+Needed because, if the user deletes `fn main`, we must build the
+file as a library (building it as an application won't work, no
+matter what `cargo` command you use)."
+  (let*
+      ((current (buffer-file-name))
+       (target (expand-file-name (if has-main "main.rs" "lib.rs") (file-name-directory current))))
+    (unless (string-equal current target)
+      (condition-case nil
+          (progn (rename-file current target)
+                 (set-visited-file-name target))
+        (file-already-exists nil)))))
 
 (defun play-rust--maybe-select-compile-command ()
   "If in a play-rust buffer, set `compile-command' to some `cargo` command line.

--- a/play-rust.el
+++ b/play-rust.el
@@ -85,19 +85,20 @@
   "Find a reasonable `cargo` command to try to run, based on the
 content of the current buffer. Also rename the file if needed
 (see `play-rust--maybe-rename-file')."
-  (let*
-      ((has-test
-        (save-excursion
-          (goto-char (point-min))
-          (re-search-forward "#\\s-*\\[\\s-*test\\s-*\\]" nil t)))
-       (has-main
-        (save-excursion
-          (goto-char (point-min))
-          (re-search-forward "\\_<fn\\s-+main\\_>" nil t))))
+  (let* ((has-test
+          (save-excursion
+            (goto-char (point-min))
+            (re-search-forward "#\\s-*\\[\\s-*test\\s-*\\]" nil t)))
+         (has-main
+          (save-excursion
+            (goto-char (point-min))
+            (re-search-forward "\\_<fn\\s-+main\\_>" nil t))))
     (play-rust--maybe-rename-file has-main)
     (concat play-rust-cargo-command
             " "
-            (cond (has-test "test") (has-main "run") (t "check"))
+            (cond (has-test "test")
+                  (has-main "run")
+                  (t "check"))
             " ")))
 
 (defun play-rust--maybe-rename-file (has-main)
@@ -108,9 +109,8 @@ buffer to `lib.rs`, so `cargo` will build it as a library. If
 Needed because, if the user deletes `fn main`, we must build the
 file as a library (building it as an application won't work, no
 matter what `cargo` command you use)."
-  (let*
-      ((current (buffer-file-name))
-       (target (expand-file-name (if has-main "main.rs" "lib.rs") (file-name-directory current))))
+  (let* ((current (buffer-file-name))
+         (target (expand-file-name (if has-main "main.rs" "lib.rs") (file-name-directory current))))
     (unless (string-equal current target)
       (condition-case nil
           (progn (rename-file current target)


### PR DESCRIPTION
With this PR, as part of the interaction advice we're adding to `compile`, if the user has deleted `fn main` we'll rename their file from `main.rs` to `lib.rs`. Later, if they put it back, we'll rename it to `main.rs` again.
